### PR TITLE
Change react-scripts to a dev dependency

### DIFF
--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -3025,9 +3025,9 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5.tgz",
-      "integrity": "sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.1.0.tgz",
+      "integrity": "sha512-rGl+jH/7x1KBCQScz9p54p0dtPLNeKGb3e0wD2H5/oZj41bwQUnXdzbj2TbUAFhvD7cp9EyEQA4dEgpUFa1O7Q==",
       "engines": {
         "node": ">=14"
       }
@@ -11061,9 +11061,9 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -13333,9 +13333,9 @@
       }
     },
     "node_modules/postcss-opacity-percentage": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
-      "integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
+      "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
       "funding": [
         {
           "type": "kofi",
@@ -13348,6 +13348,9 @@
       ],
       "engines": {
         "node": "^12 || ^14 || >=16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2"
       }
     },
     "node_modules/postcss-ordered-values": {
@@ -14057,11 +14060,11 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.5.tgz",
-      "integrity": "sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.5.0.tgz",
+      "integrity": "sha512-fqqUSU0NC0tSX0sZbyuxzuAzvGqbjiZItBQnyicWlOUmzhAU8YuLgRbaCL2hf3sJdtRy4LP/WBrWtARkMvdGPQ==",
       "dependencies": {
-        "@remix-run/router": "1.0.5"
+        "@remix-run/router": "1.1.0"
       },
       "engines": {
         "node": ">=14"
@@ -14071,12 +14074,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.5.tgz",
-      "integrity": "sha512-a7HsgikBR0wNfroBHcZUCd9+mLRqZS8R5U1Z1mzLWxFXEkUT3vR1XXmSIVoVpxVX8Bar0nQYYYc9Yipq8dWwAA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.5.0.tgz",
+      "integrity": "sha512-/XzRc5fq80gW1ctiIGilyKFZC/j4kfe75uivMsTChFbkvrK4ZrF3P3cGIc1f/SSkQ4JiJozPrf+AwUHHWVehVg==",
       "dependencies": {
-        "@remix-run/router": "1.0.5",
-        "react-router": "6.4.5"
+        "@remix-run/router": "1.1.0",
+        "react-router": "6.5.0"
       },
       "engines": {
         "node": ">=14"
@@ -19367,9 +19370,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.0.5.tgz",
-      "integrity": "sha512-my0Mycd+jruq/1lQuO5LBB6WTlL/e8DTCYWp44DfMTDcXz8DcTlgF0ISaLsGewt+ctHN+yA8xMq3q/N7uWJPug=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.1.0.tgz",
+      "integrity": "sha512-rGl+jH/7x1KBCQScz9p54p0dtPLNeKGb3e0wD2H5/oZj41bwQUnXdzbj2TbUAFhvD7cp9EyEQA4dEgpUFa1O7Q=="
     },
     "@rollup/plugin-babel": {
       "version": "5.3.1",
@@ -25341,9 +25344,9 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
+      "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ=="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -26834,9 +26837,10 @@
       }
     },
     "postcss-opacity-percentage": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.2.tgz",
-      "integrity": "sha512-lyUfF7miG+yewZ8EAk9XUBIlrHyUE6fijnesuz+Mj5zrIHIEw6KcIZSOk/elVMqzLvREmXB83Zi/5QpNRYd47w=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/postcss-opacity-percentage/-/postcss-opacity-percentage-1.1.3.tgz",
+      "integrity": "sha512-An6Ba4pHBiDtyVpSLymUUERMo2cU7s+Obz6BTrS+gxkbnSBNKSuD0AVUc+CpBMrpVPKKfoVz0WQCX+Tnst0i4A==",
+      "requires": {}
     },
     "postcss-ordered-values": {
       "version": "5.1.3",
@@ -27359,20 +27363,20 @@
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.4.5.tgz",
-      "integrity": "sha512-1RQJ8bM70YEumHIlNUYc6mFfUDoWa5EgPDenK/fq0bxD8DYpQUi/S6Zoft+9DBrh2xmtg92N5HMAJgGWDhKJ5Q==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.5.0.tgz",
+      "integrity": "sha512-fqqUSU0NC0tSX0sZbyuxzuAzvGqbjiZItBQnyicWlOUmzhAU8YuLgRbaCL2hf3sJdtRy4LP/WBrWtARkMvdGPQ==",
       "requires": {
-        "@remix-run/router": "1.0.5"
+        "@remix-run/router": "1.1.0"
       }
     },
     "react-router-dom": {
-      "version": "6.4.5",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.4.5.tgz",
-      "integrity": "sha512-a7HsgikBR0wNfroBHcZUCd9+mLRqZS8R5U1Z1mzLWxFXEkUT3vR1XXmSIVoVpxVX8Bar0nQYYYc9Yipq8dWwAA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.5.0.tgz",
+      "integrity": "sha512-/XzRc5fq80gW1ctiIGilyKFZC/j4kfe75uivMsTChFbkvrK4ZrF3P3cGIc1f/SSkQ4JiJozPrf+AwUHHWVehVg==",
       "requires": {
-        "@remix-run/router": "1.0.5",
-        "react-router": "6.4.5"
+        "@remix-run/router": "1.1.0",
+        "react-router": "6.5.0"
       }
     },
     "react-scripts": {

--- a/sample/applicationinsights-react-sample/package.json
+++ b/sample/applicationinsights-react-sample/package.json
@@ -7,16 +7,18 @@
   "dependencies": {
     "@microsoft/applicationinsights-react-js": "^3.3.6",
     "@microsoft/applicationinsights-web": "^2.8.6",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^6.3.0",
+    "web-vitals": "^2.1.4"
+  },
+  "devDependencies": {
     "@types/jest": "^27.0.2",
     "@types/node": "11.13.2",
     "@types/react": "^16.9.11",
     "@types/react-dom": "^16.9.4",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
-    "react-router-dom": "^6.3.0",
     "react-scripts": "^5.0.1",
-    "typescript": "^4.3.4",
-    "web-vitals": "^2.1.4"
+    "typescript": "^4.3.4"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This is to address internal build issues related to a CVE-2021-3803 of nth-check which is a dependency of react-scripts