### PR TITLE
modify test to show the history back problem

### DIFF
--- a/applicationinsights-react-js/test/AppInsightsErrorBoundary.test.tsx
+++ b/applicationinsights-react-js/test/AppInsightsErrorBoundary.test.tsx
@@ -94,14 +94,25 @@ describe("<AppInsightsErrorBoundary />", () => {
   });
 
   function NewError() {
+    const navigate = useNavigate();
+  
     function handleClick() {
-      history.back()
+      navigate(-1);
     }
+  
     return (
       <div>
         <button onClick={handleClick}>go back</button>
         <div>You are on the error page</div>
       </div>
+    );
+  }
+
+  function BackButton() {
+    const navigate = useNavigate();
+  
+    return (
+      <button type="button" onClick={() => navigate(-1)}>Back</button>
     );
   }
 
@@ -117,20 +128,20 @@ describe("<AppInsightsErrorBoundary />", () => {
 
     try {
       render(
-        <AppInsightsErrorBoundary appInsights={reactPlugin} onError={NewError}>
-          <Router>
+        <Router>
+          <AppInsightsErrorBoundary appInsights={reactPlugin} onError={NewError}>
             <div>
               <Link to="/">Home</Link>
               <Link to="/about">About</Link>
-              <button type="button" onClick={() => { window.history.go(-1); }}>Back</button>
+              <BackButton />
               <Routes>
                 <Route path="/" element={<Home />} />
                 <Route path="/about" element={<About />} />
               </Routes>
               <LocationDisplay />
             </div>
-          </Router>
-        </AppInsightsErrorBoundary>
+          </AppInsightsErrorBoundary>
+        </Router>
       );
       expect(screen.getByText(/Home Page/i)).toBeInTheDocument()
 

--- a/applicationinsights-react-js/test/AppInsightsErrorBoundary.test.tsx
+++ b/applicationinsights-react-js/test/AppInsightsErrorBoundary.test.tsx
@@ -94,20 +94,14 @@ describe("<AppInsightsErrorBoundary />", () => {
   });
 
   function NewError() {
-    const navigate = useNavigate();
-    const ErrorDisplay = () => <div>You are on the error page</div>;
     function handleClick() {
-      navigate(-1);
+      history.back()
     }
     return (
       <div>
         <button onClick={handleClick}>go back</button>
-      <AppInsightsErrorBoundary
-        appInsights={reactPlugin}
-        onError={ErrorDisplay}>
-      <ErrorTestComponent />
-      </AppInsightsErrorBoundary>
-    </div>
+        <div>You are on the error page</div>
+      </div>
     );
   }
 
@@ -116,48 +110,38 @@ describe("<AppInsightsErrorBoundary />", () => {
     if (orgError) {
       console.error = msg => { /* Do Nothing */ };
     }
-    const Home = () => <div>Home Page</div>
-    const About = () => <div>About Page</div>
+    const Home = () => <div>Home Page</div>;
+    const About = () => {
+      throw new Error("something went wrong");
+    };
 
     try {
       render(
-        <Router>
+        <AppInsightsErrorBoundary appInsights={reactPlugin} onError={NewError}>
+          <Router>
             <div>
-            <Link to="/">Home</Link>
-            <Link to="/about">About</Link>
-            <Link to="/error">Error</Link>
-            <button type="button" onClick={() => { window.history.go(-1); }}>Back</button>
-             <Routes>
-              <Route path="/" element={<Home />} />
-              <Route path="/about" element={<About />} />
-              <Route path="/error" element={<NewError/>} />
-            </Routes>
-            <LocationDisplay />
-          </div>
-        </Router>
+              <Link to="/">Home</Link>
+              <Link to="/about">About</Link>
+              <button type="button" onClick={() => { window.history.go(-1); }}>Back</button>
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/about" element={<About />} />
+              </Routes>
+              <LocationDisplay />
+            </div>
+          </Router>
+        </AppInsightsErrorBoundary>
       );
       expect(screen.getByText(/Home Page/i)).toBeInTheDocument()
-      
-      // go to error page
-      await userEvent.click(screen.getByText(/error/i))
-      expect(screen.getByText(/You are on the error page/i)).toBeInTheDocument()
-      expect(trackExceptionSpy).toHaveBeenCalledTimes(1);
 
-      // go back to home page
+      // navigate to about page (throws error, so show error component)
+      await userEvent.click(screen.getByText(/about/i));
+      expect(screen.getByText(/You are on the error page/i)).toBeInTheDocument();
+      console.log("track time", trackExceptionSpy.mock.calls.length);
+
+      // go back to home page (no error, so show home component)
       await userEvent.click(screen.getByText(/go back/i));
       expect(screen.getByText(/Home Page/i)).toBeInTheDocument();
-      expect(trackExceptionSpy).toHaveBeenCalledTimes(1);
-
-      // go to error page again
-      await userEvent.click(screen.getByText(/error/i))
-      expect(screen.getByText(/You are on the error page/i)).toBeInTheDocument()
-      console.log("track time", trackExceptionSpy.mock.calls.length);
-
-      // navigate to about page
-      await userEvent.click(screen.getByText(/about/i))
-      expect(screen.getByText(/About Page/i)).toBeInTheDocument()
-      console.log("track time", trackExceptionSpy.mock.calls.length);
-
     } finally {
       if (orgError) {
         console.error = orgError;


### PR DESCRIPTION
Hey @siyuniu-ms,
this is a modified version of the test to demonstrate the problem we're having.
The difference is that we don't have a designated error page but just an error component that is shown instead of the page when an error occurs, like in [this example in the documentation](https://learn.microsoft.com/en-us/azure/azure-monitor/app/javascript-framework-extensions?tabs=react#track-exceptions).