### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const browserHistory = createBrowserHistory({ basename: '' });
 var reactPlugin = new ReactPlugin();
 var appInsights = new ApplicationInsights({
     config: {
-        instrumentationKey: 'YOUR_INSTRUMENTATION_KEY_GOES_HERE',
+        connectionString: 'YOUR_CONNECTION_STRING_GOES_HERE',
         extensions: [reactPlugin],
         extensionConfig: {
           [reactPlugin.identifier]: { history: browserHistory }
@@ -53,7 +53,7 @@ For `react-router v6` or other scenarios where router history is not exposed, ap
 var reactPlugin = new ReactPlugin();
 var appInsights = new ApplicationInsights({
     config: {
-        instrumentationKey: 'YOUR_INSTRUMENTATION_KEY_GOES_HERE',
+        connectionString: 'YOUR_CONNECTION_STRING_GOES_HERE',
         enableAutoRouteTracking: true,
         extensions: [reactPlugin]
         }


### PR DESCRIPTION
Recommend connection string instead of instrumentation key. 
In accordance with [Microsoft Docs](https://learn.microsoft.com/en-us/azure/azure-monitor/app/javascript-framework-extensions?tabs=react). I think the code examples can remain minimal compared to the examples given in Microsoft Docs, which are liked.