### PR TITLE
fix(security): upgrade @nevware21/ts-utils and ws to fix CVEs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,23 @@
 # Releases
 
+## 19.4.1 (Unreleased)
+
+### Changelog
+
+- #173: Fix vulnerable dependencies, update supportability, and remove Rush
+  - Upgraded Rush 5.172.1 → 5.175.1
+  - Upgraded grunt ^1.6.1 → ^1.6.2 (fixes minimatch CVE-2026-27903, CVE-2026-27904)
+  - Upgraded jest 27 → 29, ts-jest 27 → 29, @types/jest 27 → 29
+  - Added overrides for protobufjs >=7.6.0 (CVE-2026-41242), @azure/msal-browser >=4.25.0
+  - Upgraded jest-environment-jsdom to 30.x (resolves @tootallnate/once vulnerabilities)
+  - **Removed Rush**: switched to npm workspaces for multi-package orchestration
+  - Updated CI workflow and CONTRIBUTING.md to reflect npm workspaces
+
+### Security Updates
+
+- Upgraded `@nevware21/ts-utils` minimum from `>= 0.11.3` to `>= 0.14.0` to fix **GHSA-x7j8-49r8-mr43** (HIGH: Prototype Pollution in objDeepCopy/objCopyProps)
+- Added `ws` `>=8.21.0` override to fix **GHSA-58qx-3vcg-4xpx** (MODERATE: Uninitialized memory disclosure)
+
 ## 19.4.0 (April 8th, 2026)
 
 ### Breaking Changes

--- a/applicationinsights-react-js/package.json
+++ b/applicationinsights-react-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-react-js",
-    "version": "19.4.0",
+    "version": "19.4.1",
     "description": "Microsoft Application Insights React plugin",
     "author": "Microsoft Application Insights Team",
     "license": "MIT",
@@ -70,7 +70,7 @@
         "@microsoft/applicationinsights-core-js": "^3.4.1",
         "@microsoft/applicationinsights-shims": "^3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
     },
     "peerDependencies": {
         "history": ">= 4.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@microsoft/applicationinsights-react-js",
-    "version": "19.4.0",
+    "version": "19.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@microsoft/applicationinsights-react-js",
-            "version": "19.4.0",
+            "version": "19.4.1",
             "license": "MIT",
             "workspaces": [
                 "applicationinsights-react-js",
@@ -15,7 +15,7 @@
                 "tools/release-tools"
             ],
             "dependencies": {
-                "@nevware21/ts-utils": ">= 0.11.3 < 2.x",
+                "@nevware21/ts-utils": ">= 0.14.0 < 2.x",
                 "web-vitals": "^3.4.0"
             },
             "devDependencies": {
@@ -41,13 +41,13 @@
         },
         "applicationinsights-react-js": {
             "name": "@microsoft/applicationinsights-react-js",
-            "version": "19.4.0",
+            "version": "19.4.1",
             "license": "MIT",
             "dependencies": {
                 "@microsoft/applicationinsights-core-js": "^3.4.1",
                 "@microsoft/applicationinsights-shims": "^3.0.1",
                 "@microsoft/dynamicproto-js": "^2.0.3",
-                "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+                "@nevware21/ts-utils": ">= 0.14.0 < 2.x"
             },
             "devDependencies": {
                 "@microsoft/ai-test-framework": "0.0.1",
@@ -2350,9 +2350,19 @@
             }
         },
         "node_modules/@nevware21/ts-utils": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
-            "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.14.0.tgz",
+            "integrity": "sha512-WoeqTIXQ8WPhl+lD2NbMHoAQ4sJl0n7EoRoDmVJui//Usg512enl9q1fdbVobuZt3omnxnmVsDrNIvPBvFgddQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nevware21"
+                },
+                {
+                    "type": "other",
+                    "url": "https://buymeacoffee.com/nevware21"
+                }
+            ],
             "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
@@ -11787,9 +11797,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.18.2",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
-            "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@microsoft/applicationinsights-react-js",
-    "version": "19.4.0",
+    "version": "19.4.1",
     "description": "Microsoft Application Insights React plugin",
     "author": "Microsoft Application Insights Team",
     "license": "MIT",
@@ -59,7 +59,7 @@
         "whatwg-fetch": "^3.0.0"
     },
     "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x",
+        "@nevware21/ts-utils": ">= 0.14.0 < 2.x",
         "web-vitals": "^3.4.0"
     },
     "overrides": {
@@ -68,6 +68,7 @@
         "lodash": "^4.18.1",
         "minimatch": "^3.1.5",
         "protobufjs": ">=7.6.0",
-        "@azure/msal-browser": ">=4.25.0"
+        "@azure/msal-browser": ">=4.25.0",
+        "ws": ">=8.21.0"
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,12 +1,12 @@
 {
     "description": "The release value identifies the base version that will be applied via the tools/release-tools/setVersion.js",
     "usage": "When creating a new release you should update this value directly or via the eg. 'npm run setVersion -- 3.2.0' or 'npm run setVersion -- -patch' or 'npm run setVersion -- -minor'",
-    "release": "19.4.0",
+    "release": "19.4.1",
     "next": "patch",
     "pkgs": {
         "@microsoft/applicationinsights-react-js": {
             "package": "package.json",
-            "release": "19.4.0"
+            "release": "19.4.1"
         },
         "@microsoft/applicationinsights-react-sample": {
             "package": "sample/applicationinsights-react-sample/package.json",


### PR DESCRIPTION
- Upgrade @nevware21/ts-utils >= 0.14.0 (fixes GHSA-x7j8-49r8-mr43, prototype pollution)
- Add ws >= 8.21.0 override (fixes GHSA-58qx-3vcg-4xpx, uninitialized memory disclosure)
- Update RELEASES.md with 1 changelog