### PR TITLE
fix: patch vulnerable deps and use approved Edge for local Puppeteer tests

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -28,6 +28,43 @@ module.exports = function (grunt) {
         // Converts a string into a global regex, escaping any special characters
         return new RegExp(str.replace(/([.+?^=!:${}()|\[\]\/\\])/g, '\\$1'), 'g');
     }
+
+    // Resolves the browser executable used by Puppeteer for the QUnit tests.
+    // On managed devices the Chromium that Puppeteer downloads is not on the
+    // approved software list and gets blocked by Defender/WDAC. Prefer an
+    // explicit PUPPETEER_EXECUTABLE_PATH override, otherwise fall back to the
+    // locally installed (IT-approved, signed) Microsoft Edge. Returns undefined
+    // when nothing is found so Puppeteer uses its bundled Chromium.
+    function _getBrowserExecutablePath() {
+        if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+            return process.env.PUPPETEER_EXECUTABLE_PATH;
+        }
+
+        // In CI / official release builds (e.g. Azure DevOps OneBranch) the build
+        // agent is provisioned specifically to run Puppeteer's bundled Chromium
+        // (it even installs the Server-Media-Foundation fonts feature) and does
+        // not enforce the local Defender/WDAC software policy. Leave that path
+        // untouched so the official build behaves exactly as before.
+        if (process.env.TF_BUILD || process.env.CI || process.env.BUILD_BUILDID) {
+            return undefined;
+        }
+
+        // Local managed dev machines only: fall back to installed, approved Edge.
+        var edgeCandidates = [
+            process.env["ProgramFiles(x86)"] + "\\Microsoft\\Edge\\Application\\msedge.exe",
+            process.env["ProgramFiles"] + "\\Microsoft\\Edge\\Application\\msedge.exe"
+        ];
+
+        for (var i = 0; i < edgeCandidates.length; i++) {
+            if (edgeCandidates[i] && grunt.file.exists(edgeCandidates[i])) {
+                return edgeCandidates[i];
+            }
+        }
+
+        return undefined;
+    }
+
+    var browserExecutablePath = _getBrowserExecutablePath();
     
     function setVersionNumber(path, packageVersion) {
         var expectedVersion = _createRegEx(versionPlaceholder);
@@ -258,6 +295,7 @@ module.exports = function (grunt) {
                                 headless: true, 
                                 timeout: 30000,
                                 ignoreHTTPErrors: true,
+                                executablePath: browserExecutablePath,
                                 args:[
                                     "--enable-precise-memory-info",
                                     "--expose-internals-for-testing",
@@ -310,6 +348,7 @@ module.exports = function (grunt) {
                                 headless: true, 
                                 timeout: 30000, 
                                 ignoreHTTPErrors: true,
+                                executablePath: browserExecutablePath,
                                 args:[
                                     '--enable-precise-memory-info',
                                     '--expose-internals-for-testing',

--- a/package-lock.json
+++ b/package-lock.json
@@ -205,6 +205,7 @@
             "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.7",
                 "@babel/generator": "^7.29.7",
@@ -937,6 +938,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -960,6 +962,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -1082,6 +1085,16 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -1094,6 +1107,20 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
@@ -1147,6 +1174,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@istanbuljs/schema": {
             "version": "0.1.6",
@@ -2232,6 +2266,7 @@
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -2530,6 +2565,7 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -2837,6 +2873,7 @@
             "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "undici-types": "~8.3.0"
             }
@@ -2861,6 +2898,7 @@
             "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -2871,6 +2909,7 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -2964,6 +3003,7 @@
             "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
                 "@typescript-eslint/scope-manager": "7.18.0",
@@ -2998,6 +3038,7 @@
             "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "7.18.0",
                 "@typescript-eslint/types": "7.18.0",
@@ -3185,6 +3226,7 @@
             "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3808,9 +3850,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-            "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3851,6 +3893,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.38",
                 "caniuse-lite": "^1.0.30001799",
@@ -4557,7 +4600,8 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
             "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/diff": {
             "version": "8.0.4",
@@ -4782,6 +4826,7 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -4855,6 +4900,7 @@
             "integrity": "sha512-sMStceig8AFglhhT2LqlU5r+/fn9OwsA72O5bBuQVTssPCdQAOQzL+oMn/ZcpeUY6KcNfLJArgcrsSULNjYYdQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "safe-regex": "^2.1.1"
             }
@@ -5174,9 +5220,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
             "dev": true,
             "funding": [
                 {
@@ -5698,6 +5744,7 @@
             "integrity": "sha512-bUzh5nA/P5L66ihXTDP6J5BGnMB/8lXJXejYWSbH4Y4TvWM9t2S39sggQDYYQlx06cYcCsmu63HMYHGCIzUVfg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "dateformat": "~4.6.2",
                 "eventemitter2": "~0.4.13",
@@ -6601,6 +6648,7 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -7772,9 +7820,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "dev": true,
             "funding": [
                 {
@@ -7800,6 +7848,7 @@
             "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssstyle": "^4.2.1",
                 "data-urls": "^5.0.0",
@@ -9553,6 +9602,7 @@
             "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -9563,6 +9613,7 @@
             "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -9823,6 +9874,7 @@
             "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "rollup": "dist/bin/rollup"
             },
@@ -10856,7 +10908,8 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -10930,6 +10983,7 @@
             "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"


### PR DESCRIPTION
- Bump brace-expansion (1.1.18), fast-uri (3.1.5), js-yaml (4.3.1) via npm audit fix; 0 vulnerabilities

- Normalize package-lock resolved URLs back to public registry.npmjs.org

- gruntfile: resolve Puppeteer browser to installed Edge on local managed dev machines to avoid Defender/WDAC block; CI/official builds keep bundled Chromium unchanged