### PR TITLE
Fix private feed dependency resolution

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+# Repository instructions
+
+- Dependency installation must work with both the public npm registry and Microsoft's `1ds-sdk-js` Azure Artifacts feed.
+- Do not assume that the newest version allowed by a dependency range is available from the Azure Artifacts feed. Preserve known-compatible lockfile versions and use exact npm overrides when a transitive range resolves to a version missing from the feed.
+- Keep public npm registry URLs in `package-lock.json` so external contributors can install dependencies without Microsoft credentials.
+- Before accepting a dependency update, verify that the selected package versions and tarballs are available from the `1ds-sdk-js` feed used by Microsoft builds.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "cron"
+      cronjob: "every 2 weeks"
+      timezone: "America/Los_Angeles"

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
         "lodash": "^4.18.1",
         "minimatch": "^3.1.5",
         "protobufjs": ">=7.6.0",
-        "@azure/msal-browser": ">=4.25.0"
+        "@azure/msal-browser": ">=4.25.0",
+        "electron-to-chromium": "1.5.376"
     }
 }


### PR DESCRIPTION
Pin electron-to-chromium to a version available from the 1ds-sdk-js Azure Artifacts feed and document dual-registry compatibility requirements.